### PR TITLE
Update tcp.lib

### DIFF
--- a/Lib/tcpip/tcp.lib
+++ b/Lib/tcpip/tcp.lib
@@ -4959,7 +4959,7 @@ _system int _rs_sock_puts( _rs_tcp_Socket *s, byte *dp )
         	s->sock_mode |= TCP_LOCAL;
       	_rs_sock_noflush(s);
       	if (len)
-      		_rs_sock_write(s, dp, len );
+      		len = _rs_sock_write(s, dp, len );
       	_rs_sock_flushnext(s);
       	_rs_sock_write(s, (byte *)"\r\n", 2 );
    	} else {


### PR DESCRIPTION
_rs_sock_puts() error result (-1) is not propagated / returned to caller function.